### PR TITLE
AUR package & release workflow

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,0 +1,27 @@
+name: AUR Publish 🐧
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  aur-publish:
+    name: Publish package to Arch User Repository (AUR)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish AUR package
+        uses: KSXGitHub/github-actions-deploy-aur@v2
+        with:
+          pkgname: nodejs-knit
+          pkgbuild: ./PKGBUILD
+          # update checksum(s)
+          updpkgsums: true
+          # verify build succeeds
+          test: true
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "feature(release,aur): publish AUR package"
+          ssh_keyscan_types: rsa,dsa,ecdsa,ed25519

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Brian Cooper <brian@omni.dev>
+
+_npmname="@omnidev/knit"
+_pkgname="knit"
+pkgname="nodejs-knit"
+pkgver="0.1.2"
+pkgrel="1"
+pkgdesc="🧶 Knit local dependencies together"
+url="https://github.com/coopbri/knit"
+license=("MIT")
+arch=("any")
+depends=("nodejs")
+makedepends=("npm")
+source=("https://registry.npmjs.org/${_npmname}/-/${_pkgname}-${pkgver}.tgz")
+b2sums=('a0ba793b45c0c425380999892c438d2dbea1f94ba02cf3cc99a0d50ceab7eedd42b7608c9a723d65993c7aa887a5b79411a7f7fdbbf3b8cb1bd142cb6267511c')
+
+prepare() {
+    tar xf "${_pkgname}-${pkgver}.tgz" package/LICENSE.md
+}
+
+package() {
+    npm i -g --cache "${srcdir}/npm-cache" --prefix "$pkgdir/usr" "$srcdir/$_pkgname-$pkgver.tgz"
+    install -Dm644 package/LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
## Description

- Added `PKGBUILD` for Arch User Repository (AUR)
- Added release workflow (GH Actions) to publish to AUR when new repo tags are published

## Test Steps

- On Arch Linux or a derivative thereof:
  - Lint `PKGBUILD` with [namcap](https://wiki.archlinux.org/title/namcap)
  - Verify `PKGBUILD` builds locally and installs a usable binary (`knit`)

